### PR TITLE
Fixed the read.me repo name to match the real one

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Implementations
 
-- [node-multiaddr](https://github.com/jbenet/node-multiaddr) - stable
+- [js-multiaddr](https://github.com/jbenet/js-multiaddr) - stable
 - [go-multiaddr](https://github.com/jbenet/go-multiaddr) - stable
 
 ## What is multiaddr?


### PR DESCRIPTION
Simple issue, just to make sure the names match the updates made here: https://github.com/jbenet/js-multiaddr/commit/7016abbb14374e669b96fd78d0dd875a3412a1d1